### PR TITLE
fix(agent): 排除PVE虚拟机 tap 开头的虚拟网卡，以避免虚拟机流量影响PVE宿主机监控数据。

### DIFF
--- a/cmd/agent/agent.example.yaml
+++ b/cmd/agent/agent.example.yaml
@@ -51,6 +51,7 @@ collector:
     - "^docker.*"      # 排除所有 docker 开头的接口
     - "^veth.*"        # 排除所有 veth 开头的虚拟接口
     - "^br-.*"         # 排除所有 br- 开头的网桥接口
+    - "^tap.*"         # 排除所有 tap 开头的接口（PVE/KVM 虚拟机）
 
   # 磁盘采集包含的挂载点列表（白名单）
   # 如果为空，默认采集系统主分区（Linux/macOS: "/"，Windows: "C:\"）

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -299,6 +299,7 @@ func DefaultNetworkExcludePatterns() []string {
 		"^virbr.*",   // KVM/libvirt 网桥
 		"^flannel.*", // Kubernetes Flannel
 		"^cni.*",     // Container Network Interface
+		"^tap.*",     // PVE/KVM 虚拟机 TAP 网卡
 		// macOS 虚拟接口
 		"^anpi\\d+$",   // Apple Network Process Interface
 		"^ap\\d+$",     // Apple Wireless Access Point


### PR DESCRIPTION
在默认网络接口排除规则和示例配置中添加对 tap 开头接口的排除，这些是 PVE/KVM 虚拟机使用的虚拟网卡，不应纳入网络指标采集范围。