### PR TITLE
Hide agent IP when unauthenticated

### DIFF
--- a/internal/handler/agent_query_handler.go
+++ b/internal/handler/agent_query_handler.go
@@ -26,6 +26,7 @@ func (h *AgentHandler) Get(c echo.Context) error {
 
 	// 未登录时隐藏敏感信息
 	if !isAuthenticated {
+		agent.IP = ""
 		agent.IPv4 = ""
 		agent.IPv6 = ""
 		agent.Hostname = ""


### PR DESCRIPTION
Ensure agent.IP is cleared for unauthenticated requests. Previously IPv4, IPv6 and Hostname were redacted, but agent.IP was left intact and could leak sensitive information. This change sets agent.IP to an empty string in Get() when the user is not authenticated.